### PR TITLE
Improve update command

### DIFF
--- a/cmd/set/tests/skip-if-exists/stderr.golden
+++ b/cmd/set/tests/skip-if-exists/stderr.golden
@@ -1,4 +1,4 @@
 ---- exec command line 1: [set --skip-if-exists SOME_KEY=SUCCESS]
 (no output to stderr)
 ---- exec command line 2: [set --skip-if-exists SOME_KEY=ERROR; THE VALUE MUST NOT CHANGE]
-(no output to stderr)
+WARNING: Key [ SOME_KEY ] was skipped: the key already exists in the document (SkipIfExists)

--- a/pkg/ast/document.go
+++ b/pkg/ast/document.go
@@ -52,17 +52,34 @@ func (d *Document) BelongsToGroup(name string) bool {
 func (d *Document) statementNode() {
 }
 
-func (d *Document) AllAssignments() []*Assignment {
+func (d *Document) AllAssignments(selectors ...Selector) []*Assignment {
 	var assignments []*Assignment
 
+NEXT_STATEMENT:
 	for _, statement := range d.Statements {
+		// Filter
+		for _, selector := range selectors {
+			if selector(statement) == Exclude {
+				continue NEXT_STATEMENT
+			}
+		}
+
+		// Assign
 		if assign, ok := statement.(*Assignment); ok {
 			assignments = append(assignments, assign)
 		}
 	}
 
 	for _, group := range d.Groups {
+	NEXT_GROUP_STATEMENT:
 		for _, statement := range group.Statements {
+			// FILTER
+			for _, selector := range selectors {
+				if selector(statement) == Exclude {
+					continue NEXT_GROUP_STATEMENT
+				}
+			}
+
 			if assignment, ok := statement.(*Assignment); ok {
 				assignments = append(assignments, assignment)
 			}

--- a/pkg/ast/upsert/errors.go
+++ b/pkg/ast/upsert/errors.go
@@ -1,0 +1,12 @@
+package upsert
+
+import "fmt"
+
+type SkippedStatementError struct {
+	Key    string
+	Reason string
+}
+
+func (e SkippedStatementError) Error() string {
+	return fmt.Sprintf("Key [ %s ] was skipped: %s", e.Key, e.Reason)
+}

--- a/pkg/ast/upsert/setting.go
+++ b/pkg/ast/upsert/setting.go
@@ -21,6 +21,9 @@ const (
 	// SkipIfSet will skip the upsert operation if the KEY exists in the document and *NOT* empty.
 	SkipIfSet
 
+	// SkipIfEmpty will skip the upsert operation if the KEY VALUE is empty
+	SkipIfEmpty
+
 	// Validate the KEY/VALUE pair and fail the operation if its invalid
 	Validate
 
@@ -54,7 +57,7 @@ func (bitmask Setting) Has(setting Setting) bool {
 func (setting Setting) String() string {
 	// Single key bitmask
 	switch setting {
-	case SkipIfSame, SkipIfExists, SkipIfSet, Validate, ErrorIfMissing, UpdateComments:
+	case SkipIfSame, SkipIfExists, SkipIfSet, Validate, ErrorIfMissing, UpdateComments, SkipIfEmpty:
 		return fmt.Sprintf("upsert.Setting<%s>", setting.name())
 	case maxKey:
 	}
@@ -82,6 +85,9 @@ func (setting Setting) name() string {
 
 	case SkipIfSet:
 		return "SkipIfSet"
+
+	case SkipIfEmpty:
+		return "SkipIfEmpty"
 
 	case Validate:
 		return "Validate"

--- a/pkg/ast/upsert/upsert.go
+++ b/pkg/ast/upsert/upsert.go
@@ -52,34 +52,38 @@ func (u *Upserter) ApplyOptions(options ...Option) error {
 
 // Upsert will, depending on its options, either Update or Insert (thus, "[Up]date + In[sert]").
 func (u *Upserter) Upsert(ctx context.Context, input *ast.Assignment) (*ast.Assignment, error, error) {
-	assignment := u.document.Get(input.Name)
-	exists := assignment != nil
+	existing := u.document.Get(input.Name)
+	exists := existing != nil
 
 	// Short circuit with some quick settings checks
 
 	switch {
 	// The assignment exists, so return early
 	case exists && u.settings.Has(SkipIfExists):
-		return nil, nil, nil
+		return nil, SkippedStatementError{Key: input.Name, Reason: "the KEY already exists in the document (SkipIfExists)"}, nil
 
 	// The assignment does *NOT* exists, and we require it to
 	case !exists && u.settings.Has(ErrorIfMissing):
-		return nil, nil, fmt.Errorf("key [%s] does not exists in the document", input.Name)
+		return nil, nil, fmt.Errorf("KEY [%s] does not exists in the document", input.Name)
+
+		// The assignment does not have any VALUE
+	case exists && u.settings.Has(SkipIfEmpty) && len(input.Literal) == 0:
+		return nil, SkippedStatementError{Key: input.Name, Reason: "the KEY has an empty VALUE (SkipIfEmpty)"}, nil
 
 	// The assignment exists, has a literal value, and the literal value isn't what we should consider empty
-	case exists && u.settings.Has(SkipIfSet) && len(assignment.Literal) > 0 && !slices.Contains(u.valuesConsideredEmpty, assignment.Literal):
-		return nil, nil, nil
+	case exists && u.settings.Has(SkipIfSet) && len(existing.Literal) > 0 && len(u.valuesConsideredEmpty) > 0 && !slices.Contains(u.valuesConsideredEmpty, existing.Literal):
+		return nil, SkippedStatementError{Key: input.Name, Reason: "the KEY is already set to a non-empty VALUE (SkipIfSet)"}, nil
 
-	// The assignment exists, the literal values are the same, and they have same 'Enabled' level
-	case exists && u.settings.Has(SkipIfSame) && assignment.Literal == input.Literal && assignment.Enabled == input.Enabled:
-		return nil, nil, nil
+	// The assignment exists, the literal values are the same
+	case exists && u.settings.Has(SkipIfSame) && existing.Literal == input.Literal:
+		return nil, SkippedStatementError{Key: input.Name, Reason: "the KEY has same VALUE in both documents (SkipIfSame)"}, nil
 
 	// The KEY was *NOT* found, and all other preconditions are not triggering
 	case !exists:
 		var err error
 
 		// Create and insert the (*ast.Assignment) into the Statement list
-		assignment, err = u.createAndInsert(ctx, input)
+		existing, err = u.createAndInsert(ctx, input)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -90,13 +94,13 @@ func (u *Upserter) Upsert(ctx context.Context, input *ast.Assignment) (*ast.Assi
 
 	// Replace comments on the assignment if the Setting is on
 	if u.settings.Has(UpdateComments) {
-		assignment.Comments = input.Comments
+		existing.Comments = input.Comments
 	}
 
-	assignment.Enabled = input.Enabled
-	assignment.Literal = input.Literal
-	assignment.Interpolated = input.Literal
-	assignment.Quote = input.Quote
+	existing.Enabled = input.Enabled
+	existing.Literal = input.Literal
+	existing.Interpolated = input.Literal
+	existing.Quote = input.Quote
 
 	var (
 		tempDoc       *ast.Document
@@ -104,31 +108,31 @@ func (u *Upserter) Upsert(ctx context.Context, input *ast.Assignment) (*ast.Assi
 	)
 
 	// Render and parse back the Statement to ensure annotations and such are properly handled
-	thing := u.document.AllAssignments()[:assignment.Position.Index+1]
+	thing := u.document.AllAssignments()[:existing.Position.Index+1]
 
 	tempDoc, err = parser.New(scanner.New(render.NewFormatter().Statement(ctx, thing).String()), "memory://tmp").Parse()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to parse assignment: %w", err)
 	}
 
-	assignment = tempDoc.Get(assignment.Name)
-	assignment.Initialize()
+	existing = tempDoc.Get(existing.Name)
+	existing.Initialize()
 
-	if _, ok := assignment.Dependencies[assignment.Name]; ok {
-		return nil, nil, fmt.Errorf("Key [%s] may not reference itself!", assignment.Name)
+	if _, ok := existing.Dependencies[existing.Name]; ok {
+		return nil, nil, fmt.Errorf("Key [%s] may not reference itself!", existing.Name)
 	}
 
 	// Replace the Assignment in the document
 	//
 	// This is necessary since its a different pointer address after we rendered+parsed earlier
-	u.document.Replace(assignment)
+	u.document.Replace(existing)
 
 	// Reinitialize the document so all indices and such are correct
 	u.document.Initialize()
 
 	// Interpolate the Assignment if it is enabled
-	if assignment.Enabled {
-		warnings, err = u.document.InterpolateStatement(assignment)
+	if existing.Enabled {
+		warnings, err = u.document.InterpolateStatement(existing)
 		if err != nil {
 			return nil, warnings, err
 		}
@@ -136,15 +140,15 @@ func (u *Upserter) Upsert(ctx context.Context, input *ast.Assignment) (*ast.Assi
 
 	// Validate
 	if u.settings.Has(Validate) {
-		if validationErrors, warns, errs := u.document.ValidateSingleAssignment(assignment, nil, u.ignoreValidationRules); len(validationErrors) > 0 {
+		if validationErrors, warns, errs := u.document.ValidateSingleAssignment(existing, nil, u.ignoreValidationRules); len(validationErrors) > 0 {
 			warnings = multierr.Append(warnings, warns)
 			errs = multierr.Append(errs, validationErrors)
 
-			return assignment, warnings, errs
+			return existing, warnings, errs
 		}
 	}
 
-	return assignment, warnings, nil
+	return existing, warnings, nil
 }
 
 func (u *Upserter) createAndInsert(ctx context.Context, input *ast.Assignment) (*ast.Assignment, error) {
@@ -154,9 +158,10 @@ func (u *Upserter) createAndInsert(ctx context.Context, input *ast.Assignment) (
 		Enabled:  input.Enabled,
 		Literal:  input.Literal,
 		Name:     input.Name,
+		Quote:    input.Quote,
 	}
 
-	doc, err := parser.New(scanner.New(render.NewFormatter().Statement(ctx, newAssignment).String()), "-").Parse()
+	inMemoryDoc, err := parser.New(scanner.New(render.NewFormatter().Statement(ctx, newAssignment).String()), "-").Parse()
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse assignment: %w", err)
 	}
@@ -164,7 +169,7 @@ func (u *Upserter) createAndInsert(ctx context.Context, input *ast.Assignment) (
 	// Ensure the group exists (may return 'nil' if no group is required)
 	group := u.document.EnsureGroup(u.group)
 
-	newAssignment = doc.Get(newAssignment.Name)
+	newAssignment = inMemoryDoc.Get(newAssignment.Name)
 	newAssignment.Group = group
 
 	// Find the statement slice to operate on
@@ -189,6 +194,8 @@ func (u *Upserter) createAndInsert(ctx context.Context, input *ast.Assignment) (
 	// If the new assignment is desired to be placed relative to another key,
 	// we will figure out the ordering here
 	case AddAfterKey, AddBeforeKey:
+		var inserted bool
+
 		// Run through all the statements
 		for _, stmtInterface := range statements {
 			// If the rangeStatement isn't an [Assignment], append it to the
@@ -213,14 +220,22 @@ func (u *Upserter) createAndInsert(ctx context.Context, input *ast.Assignment) (
 			//   * Append the new assignment
 			//   * Append the current range statement
 			case AddBeforeKey:
+				inserted = true
+
 				res = append(res, newAssignment, rangeStatement)
 
 			// If placement is desired *AFTER* another KEY, then
 			//   * Append the current range statement
 			//   * Append the new assignment
 			case AddAfterKey:
+				inserted = true
+
 				res = append(res, rangeStatement, newAssignment)
 			}
+		}
+
+		if !inserted {
+			panic(fmt.Errorf("could not insert statement into doc: %s (%s %s)", newAssignment.Name, u.placement, u.placementValue))
 		}
 
 	default:

--- a/pkg/ast/upsert/upsert.go
+++ b/pkg/ast/upsert/upsert.go
@@ -60,23 +60,23 @@ func (u *Upserter) Upsert(ctx context.Context, input *ast.Assignment) (*ast.Assi
 	switch {
 	// The assignment exists, so return early
 	case exists && u.settings.Has(SkipIfExists):
-		return nil, SkippedStatementError{Key: input.Name, Reason: "the KEY already exists in the document (SkipIfExists)"}, nil
+		return nil, SkippedStatementError{Key: input.Name, Reason: "the key already exists in the document (SkipIfExists)"}, nil
 
 	// The assignment does *NOT* exists, and we require it to
 	case !exists && u.settings.Has(ErrorIfMissing):
-		return nil, nil, fmt.Errorf("KEY [%s] does not exists in the document", input.Name)
+		return nil, nil, fmt.Errorf("key [%s] does not exists in the document", input.Name)
 
 		// The assignment does not have any VALUE
 	case exists && u.settings.Has(SkipIfEmpty) && len(input.Literal) == 0:
-		return nil, SkippedStatementError{Key: input.Name, Reason: "the KEY has an empty VALUE (SkipIfEmpty)"}, nil
+		return nil, SkippedStatementError{Key: input.Name, Reason: "the key has an empty value (SkipIfEmpty)"}, nil
 
 	// The assignment exists, has a literal value, and the literal value isn't what we should consider empty
 	case exists && u.settings.Has(SkipIfSet) && len(existing.Literal) > 0 && len(u.valuesConsideredEmpty) > 0 && !slices.Contains(u.valuesConsideredEmpty, existing.Literal):
-		return nil, SkippedStatementError{Key: input.Name, Reason: "the KEY is already set to a non-empty VALUE (SkipIfSet)"}, nil
+		return nil, SkippedStatementError{Key: input.Name, Reason: "the key is already set to a non-empty value (SkipIfSet)"}, nil
 
 	// The assignment exists, the literal values are the same
 	case exists && u.settings.Has(SkipIfSame) && existing.Literal == input.Literal:
-		return nil, SkippedStatementError{Key: input.Name, Reason: "the KEY has same VALUE in both documents (SkipIfSame)"}, nil
+		return nil, SkippedStatementError{Key: input.Name, Reason: "the key has same value in both documents (SkipIfSame)"}, nil
 
 	// The KEY was *NOT* found, and all other preconditions are not triggering
 	case !exists:


### PR DESCRIPTION
- allow selectors on `document.AllStatements`
- print warnings when `upsert` skips a statement (with the reason/context)
- add `SkipIfEmpty` upserter setting for skipping empty statements being copied over
- detect keys not being upserted due to invalid placements
- `update` command now supports skipping keys by prefix from `source` document