### PR TITLE
Auto-create target file if missing

### DIFF
--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -59,8 +59,13 @@ func runE(cmd *cobra.Command, args []string) error {
 	noColor.Println("Looking for source configuration")
 
 	oldDocument, err := pkg.Load(cmd.Context(), filename)
-	if err != nil {
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
+	}
+
+	if oldDocument == nil {
+		// File did not exist, let's create a new one
+		oldDocument = ast.NewDocument()
 	}
 
 	source, _ := cmd.Flags().GetString("source")

--- a/cmd/update/update_test.go
+++ b/cmd/update/update_test.go
@@ -1,13 +1,43 @@
 package update_test
 
 import (
+	"bytes"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/jippi/dottie/cmd"
 	"github.com/jippi/dottie/pkg/test_helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSetCommand(t *testing.T) {
 	t.Parallel()
 
 	test_helpers.RunFileBasedCommandTests(t, 0, "update")
+}
+
+func TestCreateIfMissing(t *testing.T) {
+	t.Parallel()
+
+	targetFile := filepath.Join(t.TempDir(), "missing.env")
+
+	var stdout, stderr bytes.Buffer
+
+	ctx := test_helpers.CreateTestContext(t, &stdout, &stderr)
+
+	_, err := cmd.RunCommand(ctx, []string{
+		"update",
+		"--source", "tests/source-flag.source",
+		"--no-backup",
+		"--no-validate",
+		"--file", targetFile,
+	}, &stdout, &stderr)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(targetFile)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(content), `KEY="source"`)
 }


### PR DESCRIPTION
## Summary

When a project is freshly cloned (or a new `.env` file is added to an existing project), `dottie update` fails with `open .env: no such file or directory`. The fix is always the same - manually `touch` or `cp` _something_ into place, then re-run the command.

Instead, **let's just auto-create the missing target by default.**

Since there are no existing values to merge, the source is used as-is - which is exactly what you'd get from the manual touch-then-update workflow, but without the extra step.

## Changes

- **`cmd/update/update.go`** — On `os.ErrNotExist` from `pkg.Load()`, use an empty `ast.NewDocument()` instead of erroring out
- **`cmd/update/update_test.go`** — Added `TestCreateIfMissing` covering the new behavior
